### PR TITLE
chore: rename lenster to hey

### DIFF
--- a/lens-widgets-react/src/ShareToLens.tsx
+++ b/lens-widgets-react/src/ShareToLens.tsx
@@ -30,7 +30,7 @@ export function ShareToLens({
   iconForegroundColor?: string
 }) {
   function navigate() {
-    let shareUrl = `https://lenster.xyz/?text=${encodeURIComponent(content)}`
+    let shareUrl = `https://hey.xyz/?text=${encodeURIComponent(content)}`
     if (url) {
       shareUrl = shareUrl + `&url=${url}`
     }


### PR DESCRIPTION
We just rebranded lenster.xyz to hey.xyz

https://twitter.com/heydotxyz/status/1707431312385253477